### PR TITLE
The decoder fails parsing zero-length boxes

### DIFF
--- a/test.js
+++ b/test.js
@@ -12,6 +12,11 @@ tape('generates and parses', function (t) {
         t.same(box.brand, 'mafi')
         t.same(box.brandVersion, 1)
       })
+    } else if (headers.type === 'free') {
+      decode.decode(function (box) {
+        t.same(box.type, 'free')
+        t.same(box.buffer.length, 0)
+      })
     } else if (headers.type === 'mdat') {
       t.same(headers.type, 'mdat')
       t.same(headers.length, 8 + 11)
@@ -33,6 +38,11 @@ tape('generates and parses', function (t) {
     type: 'ftyp',
     brand: 'mafi',
     brandVersion: 1
+  })
+
+  encode.box({
+    type: 'free',
+    buffer: new Buffer(0)
   })
 
   var stream = encode.mediaData(11)


### PR DESCRIPTION
There is a bug where the decoder halts after encountering a zero-length box. 

E.g. calling `decode(function(box))` in the handler for the `box` event, never calls the provided callback if the box has a `contentLen` of zero. The `ignore` method is also affected by this.

This pull-request contains a failing test.

A quick solution for only fixing `decode` would be to add a zero-length check to the `Decoder.prototype._buffer` method.

```js
Decoder.prototype._buffer = function (size, cb) {
  if (!size) return cb(new Buffer(0))      // This fixes the test. But ignore and stream are still affected.
  this._missing = size
  this._buf = new Buffer(size)
  this._cb = cb
}
```

I think similar checks could also be added to `Decoder.prototype._stream` and `Decoder.prototype.ignore` methods.